### PR TITLE
Phase 2: Product UX polish

### DIFF
--- a/e2e/collaboration.spec.ts
+++ b/e2e/collaboration.spec.ts
@@ -64,6 +64,21 @@ test.describe('Room page', () => {
 
 		await expect(editor).toContainText('Hello syncingsh!');
 	});
+
+	test('should show share link feedback', async ({ page }) => {
+		await page.addInitScript(() => {
+			Object.defineProperty(navigator, 'clipboard', {
+				value: { writeText: async () => undefined },
+				configurable: true
+			});
+		});
+		await page.goto('/room/e2e-test-share');
+		await page.locator('.tiptap').waitFor({ timeout: 10000 });
+
+		await page.getByRole('button', { name: '링크 복사' }).click();
+
+		await expect(page.getByText('링크를 복사했습니다')).toBeVisible();
+	});
 });
 
 test.describe('Real-time collaboration (same-browser fallback)', () => {

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -50,7 +50,7 @@
 	});
 </script>
 
-<div class="editor-wrapper">
+<div class="editor-wrapper px-2 sm:px-0">
 	<div bind:this={element}></div>
 </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -43,6 +43,11 @@
 		<div class="text-center">
 			<h1 class="text-3xl font-bold text-gray-900">syncingsh</h1>
 			<p class="mt-2 text-gray-500">실시간 공유 메모장</p>
+			<div class="mt-4 space-y-1 rounded-lg bg-gray-100 px-4 py-3 text-left text-sm text-gray-700">
+				<p><span class="font-semibold">로그인 없이</span> 바로 시작</p>
+				<p><span class="font-semibold">링크나 방 코드만 공유</span>하면 누구나 참여</p>
+				<p>실시간 서버 키가 없을 때도 이 브라우저에 임시 복구됩니다</p>
+			</div>
 		</div>
 
 		<div class="space-y-2">

--- a/src/routes/room/[roomId]/+page.svelte
+++ b/src/routes/room/[roomId]/+page.svelte
@@ -24,6 +24,8 @@
 	let nickname = $state('');
 	let editingName = $state(false);
 	let errorMessage = $state<string | null>(null);
+	let copyFeedback = $state('');
+	let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	let tabs = $state<TabMeta[]>([]);
 	let activeTabId = $state<string>('');
@@ -117,6 +119,19 @@
 
 	function switchTab(tabId: string) {
 		activeTabId = tabId;
+	}
+
+	async function copyRoomLink() {
+		try {
+			if (!navigator.clipboard) throw new Error('Clipboard unavailable');
+			await navigator.clipboard.writeText(window.location.href);
+			copyFeedback = '링크를 복사했습니다';
+		} catch {
+			copyFeedback = '주소창의 링크를 복사해 공유하세요';
+		}
+
+		if (copyTimeout) clearTimeout(copyTimeout);
+		copyTimeout = setTimeout(() => (copyFeedback = ''), 5000);
 	}
 
 	function storageKey() {
@@ -288,7 +303,7 @@
 </script>
 
 <div class="mx-auto max-w-4xl px-4 py-6">
-	<header class="mb-4 flex items-center justify-between">
+	<header class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 		<div>
 			<h1 class="text-lg font-semibold text-gray-900">Room: {roomId}</h1>
 			<div class="mt-1 flex items-center gap-2">
@@ -323,7 +338,17 @@
 				></span>
 			</div>
 		</div>
-		<div class="flex items-center gap-3">
+		<div class="flex flex-wrap items-center gap-2 sm:justify-end">
+			<button
+				onclick={copyRoomLink}
+				title="방 링크 복사"
+				class="rounded border border-gray-200 bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-200"
+			>
+				링크 복사
+			</button>
+			{#if copyFeedback}
+				<span class="text-xs text-green-600" aria-live="polite">{copyFeedback}</span>
+			{/if}
 			{#if awareness}
 				<Presence {awareness} />
 			{/if}
@@ -332,7 +357,8 @@
 
 	{#if errorMessage}
 		<div class="mb-4 rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-			{errorMessage}
+			<p>{errorMessage}</p>
+			<p class="mt-1 text-xs">같은 브라우저 탭끼리는 계속 동기화되고, 새로고침해도 복구됩니다.</p>
 		</div>
 	{/if}
 
@@ -351,7 +377,18 @@
 				<Editor fragment={activeFragment} />
 			{/key}
 		{/if}
+	{:else if connectionStatus === 'connecting'}
+		<div class="flex h-64 items-center justify-center text-gray-400">서버에 연결 중입니다...</div>
+	{:else if connectionStatus === 'disconnected'}
+		<div class="flex h-64 items-center justify-center text-red-400">
+			연결이 끊어졌습니다. 새로고침 해보세요.
+		</div>
+	{:else if connectionStatus === 'error'}
+		<div class="flex h-64 items-center justify-center text-amber-600">
+			로컬 모드로 실행 중입니다. 이 브라우저에서만 편집 내용이 저장되며, 서버에는 아무 데이터도 남지
+			않습니다.
+		</div>
 	{:else}
-		<div class="flex h-64 items-center justify-center text-gray-400">연결 중...</div>
+		<div class="flex h-64 items-center justify-center text-gray-400">문서를 불러오는 중...</div>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary
- Adds concise landing-page guidance for no-login sharing and local recovery behavior.
- Adds room link-copy feedback, clearer degraded-state copy, and a more mobile-friendly room header/editor spacing.
- Covers the link-copy feedback in Playwright.

## Verification
- npm run check
- npm test
- npm run test:e2e (9 passed, 3 skipped without VITE_LIVEBLOCKS_PUBLIC_KEY)
- Manual Playwright MCP QA: confirmed landing guidance, mobile-width room layout, degraded-state copy, and visible link-copy feedback.

Closes #26