### PR TITLE
Phase 3: Collaboration stability hardening

### DIFF
--- a/e2e/collaboration.spec.ts
+++ b/e2e/collaboration.spec.ts
@@ -79,6 +79,19 @@ test.describe('Room page', () => {
 
 		await expect(page.getByText('링크를 복사했습니다')).toBeVisible();
 	});
+
+	test('should show degraded local recovery mode without Liveblocks key', async ({ page }) => {
+		test.skip(
+			!!process.env.VITE_LIVEBLOCKS_PUBLIC_KEY,
+			'Only applies when Liveblocks key is absent'
+		);
+
+		await page.goto('/room/e2e-degraded-mode');
+
+		await expect(page.locator('.tiptap')).toBeVisible({ timeout: 10000 });
+		await expect(page.getByText('Liveblocks 공개 키가 없어')).toBeVisible();
+		await expect(page.getByText('새로고침해도 복구됩니다')).toBeVisible();
+	});
 });
 
 test.describe('Real-time collaboration (same-browser fallback)', () => {

--- a/src/routes/room/[roomId]/+page.svelte
+++ b/src/routes/room/[roomId]/+page.svelte
@@ -154,21 +154,42 @@
 			const stored = localStorage.getItem(storageKey());
 			if (stored) Y.applyUpdate(doc, base64ToUpdate(stored));
 		} catch {
-			localStorage.removeItem(storageKey());
+			try {
+				localStorage.removeItem(storageKey());
+			} catch {
+				// Storage can be unavailable in private or restricted browser contexts.
+			}
 		}
 	}
 
 	function persistLocalDoc(doc: Y.Doc) {
-		localStorage.setItem(storageKey(), updateToBase64(Y.encodeStateAsUpdate(doc)));
+		try {
+			localStorage.setItem(storageKey(), updateToBase64(Y.encodeStateAsUpdate(doc)));
+		} catch {
+			// Keep editing even when local persistence is unavailable.
+		}
+	}
+
+	function fallbackOrigin() {
+		return crypto.randomUUID?.() ?? Math.random().toString(36).slice(2);
 	}
 
 	function connectLocalFallback(doc: Y.Doc) {
+		if (typeof BroadcastChannel === 'undefined') {
+			doc.on('update', () => persistLocalDoc(doc));
+			return () => {};
+		}
+
 		const channel = new BroadcastChannel(`syncingsh:${roomId}`);
-		const origin = crypto.randomUUID();
+		const origin = fallbackOrigin();
 
 		const onUpdate = (update: Uint8Array) => {
 			persistLocalDoc(doc);
-			channel.postMessage({ origin, update: updateToBase64(update) });
+			try {
+				channel.postMessage({ origin, update: updateToBase64(update) });
+			} catch {
+				// Local persistence still protects reload recovery if cross-tab broadcast fails.
+			}
 		};
 
 		channel.onmessage = (event) => {
@@ -176,18 +197,30 @@
 			if (message.origin === origin) return;
 
 			if (message.requestSync) {
-				channel.postMessage({ origin, update: updateToBase64(Y.encodeStateAsUpdate(doc)) });
+				try {
+					channel.postMessage({ origin, update: updateToBase64(Y.encodeStateAsUpdate(doc)) });
+				} catch {
+					// Ignore failed sync responses; the local document remains editable.
+				}
 				return;
 			}
 
 			if (message.update) {
-				Y.applyUpdate(doc, base64ToUpdate(message.update), 'remote');
-				persistLocalDoc(doc);
+				try {
+					Y.applyUpdate(doc, base64ToUpdate(message.update), 'remote');
+					persistLocalDoc(doc);
+				} catch {
+					// Ignore malformed peer updates.
+				}
 			}
 		};
 
 		doc.on('update', onUpdate);
-		channel.postMessage({ origin, requestSync: true });
+		try {
+			channel.postMessage({ origin, requestSync: true });
+		} catch {
+			// Broadcast sync is best-effort.
+		}
 
 		return () => {
 			doc.off('update', onUpdate);


### PR DESCRIPTION
## Summary
- Guards localStorage cleanup/write paths so restricted browser storage does not break editing.
- Makes BroadcastChannel sync best-effort, including malformed update and postMessage failure handling.
- Adds degraded local recovery mode e2e coverage.

## Verification
- npm run check
- npm test
- npm run test:e2e (10 passed, 3 skipped without VITE_LIVEBLOCKS_PUBLIC_KEY)
- Manual Playwright MCP QA: verified degraded mode is visible and typed content survives reload.

Closes #28