### PR TITLE
Phase 4: Plain text export

### DIFF
--- a/e2e/collaboration.spec.ts
+++ b/e2e/collaboration.spec.ts
@@ -109,6 +109,21 @@ test.describe('Room page', () => {
 		await expect(editor).not.toContainText('Should not appear');
 	});
 
+	test('should export current document as text', async ({ page }) => {
+		await page.goto('/room/e2e-export');
+
+		const editor = page.locator('.tiptap');
+		await editor.waitFor({ timeout: 10000 });
+		await editor.click();
+		await page.keyboard.type('Exported content');
+
+		const downloadPromise = page.waitForEvent('download');
+		await page.getByRole('button', { name: '내보내기' }).click();
+		const download = await downloadPromise;
+
+		expect(download.suggestedFilename()).toBe('문서 1.txt');
+	});
+
 	test('should show degraded local recovery mode without Liveblocks key', async ({ page }) => {
 		test.skip(
 			!!process.env.VITE_LIVEBLOCKS_PUBLIC_KEY,

--- a/src/routes/room/[roomId]/+page.svelte
+++ b/src/routes/room/[roomId]/+page.svelte
@@ -151,6 +151,18 @@
 		copyTimeout = setTimeout(() => (copyFeedback = ''), 5000);
 	}
 
+	function exportCurrentTab() {
+		const activeTab = tabs.find((tab) => tab.id === activeTabId);
+		const text = document.querySelector('.tiptap')?.textContent?.trim() ?? '';
+		const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement('a');
+		link.href = url;
+		link.download = `${activeTab?.name ?? roomId}.txt`;
+		link.click();
+		URL.revokeObjectURL(url);
+	}
+
 	function storageKey() {
 		return `syncingsh_room_${roomId}`;
 	}
@@ -402,6 +414,13 @@
 				class="rounded border border-gray-200 bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-200"
 			>
 				읽기 전용 링크
+			</button>
+			<button
+				onclick={exportCurrentTab}
+				title="현재 문서 내보내기"
+				class="rounded border border-gray-200 bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-200"
+			>
+				내보내기
 			</button>
 			{#if copyFeedback}
 				<span class="text-xs text-green-600" aria-live="polite">{copyFeedback}</span>


### PR DESCRIPTION
## Summary
- Adds an export action for the active document tab as a `.txt` download.
- Covers the download behavior in Playwright.

## Verification
- npm run check
- npm test
- npm run test:e2e -- --grep "export current"

Closes #34