### PR TITLE
Phase 4: Presence visibility

### DIFF
--- a/e2e/collaboration.spec.ts
+++ b/e2e/collaboration.spec.ts
@@ -53,6 +53,12 @@ test.describe('Room page', () => {
 		await expect(input).toBeVisible();
 	});
 
+	test('should show solo presence state', async ({ page }) => {
+		await page.goto('/room/e2e-solo-presence');
+
+		await expect(page.getByText('나만 접속 중')).toBeVisible({ timeout: 10000 });
+	});
+
 	test('should allow typing in the editor', async ({ page }) => {
 		await page.goto('/room/e2e-test-typing');
 

--- a/src/lib/components/Presence.svelte
+++ b/src/lib/components/Presence.svelte
@@ -29,7 +29,13 @@
 			const result: User[] = [];
 
 			states.forEach((state, clientId) => {
-				if (clientId !== localId && state !== null && typeof state === 'object' && 'user' in state && state.user) {
+				if (
+					clientId !== localId &&
+					state !== null &&
+					typeof state === 'object' &&
+					'user' in state &&
+					state.user
+				) {
 					result.push(state.user as User);
 				}
 			});
@@ -46,8 +52,8 @@
 	});
 </script>
 
-{#if users.length > 0}
-	<div class="flex items-center gap-1.5">
+<div class="flex items-center gap-1.5">
+	{#if users.length > 0}
 		{#each users as user (user.name)}
 			<span
 				class="inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium text-white"
@@ -58,5 +64,7 @@
 			</span>
 		{/each}
 		<span class="ml-1 text-sm text-gray-500">{users.length}명</span>
-	</div>
-{/if}
+	{:else}
+		<span class="text-xs text-gray-400">나만 접속 중</span>
+	{/if}
+</div>

--- a/src/routes/room/[roomId]/+page.svelte
+++ b/src/routes/room/[roomId]/+page.svelte
@@ -427,6 +427,8 @@
 			{/if}
 			{#if awareness}
 				<Presence {awareness} />
+			{:else}
+				<span class="text-xs text-gray-400">나만 접속 중</span>
 			{/if}
 		</div>
 	</header>


### PR DESCRIPTION
## Summary
- Shows a solo presence state when no peers are connected or Liveblocks awareness is unavailable.
- Preserves existing peer avatar/count display.
- Adds Playwright coverage for solo presence visibility.

## Verification
- npm run check
- npm test
- npm run test:e2e -- --grep "solo presence"

Closes #36