### PR TITLE
Encrypt local recovery data

### DIFF
--- a/e2e/collaboration.spec.ts
+++ b/e2e/collaboration.spec.ts
@@ -18,7 +18,7 @@ test.describe('Landing page', () => {
 		await page.getByPlaceholder('방 코드 입력').fill('abcd1234');
 		await page.getByRole('button', { name: '참여하기' }).click();
 
-		await expect(page).toHaveURL('/room/abcd1234');
+		await expect(page).toHaveURL(/\/room\/abcd1234#key=.+/);
 	});
 
 	test('should show error for invalid room code', async ({ page }) => {
@@ -146,13 +146,26 @@ test.describe('Room page', () => {
 
 test.describe('Real-time collaboration (same-browser fallback)', () => {
 	test('two tabs should sync content via BroadcastChannel', async ({ context }) => {
-		const roomPath = '/room/e2e-sync-test';
+		await context.addInitScript(() => {
+			const OriginalBroadcastChannel = window.BroadcastChannel;
+			(window as any).__syncingshBroadcastMessages = [];
+
+			window.BroadcastChannel = class extends OriginalBroadcastChannel {
+				postMessage(message: unknown) {
+					(window as any).__syncingshBroadcastMessages.push(message);
+					return super.postMessage(message);
+				}
+			};
+		});
+
+		const roomPath = `/room/e2e-sync-test-${Date.now()}`;
 
 		const page1 = await context.newPage();
 		const page2 = await context.newPage();
 
 		await page1.goto(roomPath);
-		await page2.goto(roomPath);
+		await page1.locator('.tiptap').waitFor({ timeout: 10000 });
+		await page2.goto(page1.url());
 
 		// Wait for both editors to load
 		const editor1 = page1.locator('.tiptap');
@@ -166,6 +179,15 @@ test.describe('Real-time collaboration (same-browser fallback)', () => {
 
 		// Verify it appears in page2
 		await expect(editor2).toContainText('Synced message from tab 1', { timeout: 10000 });
+
+		const broadcastMessages = await page1.evaluate(() =>
+			((window as any).__syncingshBroadcastMessages ?? []).filter(
+				(message: any) => message.encryptedUpdate
+			)
+		);
+		expect(broadcastMessages.length).toBeGreaterThan(0);
+		expect(broadcastMessages.every((message: any) => !message.update)).toBe(true);
+		expect(JSON.stringify(broadcastMessages)).not.toContain('Synced message from tab 1');
 	});
 
 	test('presence should update when peer connects', async ({ context }) => {
@@ -259,7 +281,8 @@ test.describe('Liveblocks sync (cross-browser, WebSocket)', () => {
 
 test.describe('Local reload recovery', () => {
 	test('should restore room content after reload', async ({ page }) => {
-		const roomPath = `/room/e2e-reload-${Date.now()}`;
+		const roomId = `e2e-reload-${Date.now()}`;
+		const roomPath = `/room/${roomId}`;
 
 		await page.goto(roomPath);
 		const editor = page.locator('.tiptap');
@@ -268,6 +291,17 @@ test.describe('Local reload recovery', () => {
 		await editor.click();
 		await page.keyboard.type('Recovered after reload');
 		await expect(editor).toContainText('Recovered after reload');
+
+		const stored = await page.waitForFunction(
+			(key) => localStorage.getItem(key),
+			`syncingsh_room_${roomId}`
+		);
+		const storedValue = await stored.jsonValue<string>();
+		const envelope = JSON.parse(storedValue);
+		expect(envelope).toMatchObject({ v: 1, alg: 'AES-GCM' });
+		expect(envelope).toHaveProperty('iv');
+		expect(envelope).toHaveProperty('data');
+		expect(storedValue).not.toContain('Recovered after reload');
 
 		await page.reload();
 		await expect(page.locator('.tiptap')).toContainText('Recovered after reload', {

--- a/src/lib/utils/localEncryption.ts
+++ b/src/lib/utils/localEncryption.ts
@@ -1,0 +1,126 @@
+const KEY_HASH_PARAM = 'key';
+const KEY_BYTE_LENGTH = 32;
+const IV_BYTE_LENGTH = 12;
+
+export interface EncryptedEnvelope {
+	v: 1;
+	alg: 'AES-GCM';
+	iv: string;
+	data: string;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+	let binary = '';
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+	const normalized = value.replaceAll('-', '+').replaceAll('_', '/');
+	const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+	const binary = atob(padded);
+	return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+export function isEncryptedEnvelope(value: unknown): value is EncryptedEnvelope {
+	return (
+		!!value &&
+		typeof value === 'object' &&
+		(value as EncryptedEnvelope).v === 1 &&
+		(value as EncryptedEnvelope).alg === 'AES-GCM' &&
+		typeof (value as EncryptedEnvelope).iv === 'string' &&
+		typeof (value as EncryptedEnvelope).data === 'string'
+	);
+}
+
+export function generateRoomKey(): string {
+	const key = new Uint8Array(KEY_BYTE_LENGTH);
+	crypto.getRandomValues(key);
+	return bytesToBase64Url(key);
+}
+
+export function ensureRoomKey(url: URL): string {
+	const existingKey = url.hash.startsWith('#')
+		? new URLSearchParams(url.hash.slice(1)).get(KEY_HASH_PARAM)
+		: null;
+
+	if (existingKey) return existingKey;
+
+	const generatedKey = generateRoomKey();
+	const hashParams = new URLSearchParams(url.hash.slice(1));
+	hashParams.set(KEY_HASH_PARAM, generatedKey);
+	url.hash = hashParams.toString();
+	history.replaceState(history.state, '', url);
+	return generatedKey;
+}
+
+export function parseEncryptedEnvelope(value: string): EncryptedEnvelope | null {
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return isEncryptedEnvelope(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+export async function importRoomKey(roomKey: string): Promise<CryptoKey> {
+	const keyBytes = base64UrlToBytes(roomKey);
+	if (keyBytes.byteLength !== KEY_BYTE_LENGTH) throw new Error('Invalid room key length');
+
+	return crypto.subtle.importKey('raw', toArrayBuffer(keyBytes), 'AES-GCM', false, [
+		'encrypt',
+		'decrypt'
+	]);
+}
+
+export async function encryptBytes(
+	key: CryptoKey,
+	plaintext: Uint8Array
+): Promise<EncryptedEnvelope> {
+	const iv = new Uint8Array(IV_BYTE_LENGTH);
+	crypto.getRandomValues(iv);
+	const ciphertext = await crypto.subtle.encrypt(
+		{ name: 'AES-GCM', iv: toArrayBuffer(iv) },
+		key,
+		toArrayBuffer(plaintext)
+	);
+
+	return {
+		v: 1,
+		alg: 'AES-GCM',
+		iv: bytesToBase64Url(iv),
+		data: bytesToBase64Url(new Uint8Array(ciphertext))
+	};
+}
+
+export async function decryptEnvelope(
+	key: CryptoKey,
+	envelope: EncryptedEnvelope
+): Promise<Uint8Array> {
+	const plaintext = await crypto.subtle.decrypt(
+		{ name: 'AES-GCM', iv: toArrayBuffer(base64UrlToBytes(envelope.iv)) },
+		key,
+		toArrayBuffer(base64UrlToBytes(envelope.data))
+	);
+
+	return new Uint8Array(plaintext);
+}
+
+export function serializeEnvelope(envelope: EncryptedEnvelope): string {
+	return JSON.stringify(envelope);
+}
+
+export function updateToBase64(update: Uint8Array): string {
+	let binary = '';
+	for (const byte of update) binary += String.fromCharCode(byte);
+	return btoa(binary);
+}
+
+export function base64ToUpdate(value: string): Uint8Array {
+	const binary = atob(value);
+	return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}

--- a/src/routes/room/[roomId]/+page.svelte
+++ b/src/routes/room/[roomId]/+page.svelte
@@ -8,6 +8,16 @@
 	import TabBar from '$lib/components/TabBar.svelte';
 	import Presence from '$lib/components/Presence.svelte';
 	import { getNickname, setNickname, getUserColor } from '$lib/utils/nickname';
+	import {
+		base64ToUpdate,
+		decryptEnvelope,
+		encryptBytes,
+		ensureRoomKey,
+		importRoomKey,
+		isEncryptedEnvelope,
+		parseEncryptedEnvelope,
+		serializeEnvelope
+	} from '$lib/utils/localEncryption';
 	import type { ConnectionStatus } from '$lib/types/yjs';
 
 	interface TabMeta {
@@ -167,21 +177,18 @@
 		return `syncingsh_room_${roomId}`;
 	}
 
-	function updateToBase64(update: Uint8Array): string {
-		let binary = '';
-		for (const byte of update) binary += String.fromCharCode(byte);
-		return btoa(binary);
-	}
-
-	function base64ToUpdate(value: string): Uint8Array {
-		const binary = atob(value);
-		return Uint8Array.from(binary, (char) => char.charCodeAt(0));
-	}
-
-	function restoreLocalDoc(doc: Y.Doc) {
+	async function restoreLocalDoc(doc: Y.Doc, encryptionKey: CryptoKey) {
 		try {
 			const stored = localStorage.getItem(storageKey());
-			if (stored) Y.applyUpdate(doc, base64ToUpdate(stored));
+			if (!stored) return;
+
+			const envelope = parseEncryptedEnvelope(stored);
+			if (envelope) {
+				Y.applyUpdate(doc, await decryptEnvelope(encryptionKey, envelope));
+				return;
+			}
+
+			Y.applyUpdate(doc, base64ToUpdate(stored));
 		} catch {
 			try {
 				localStorage.removeItem(storageKey());
@@ -191,9 +198,10 @@
 		}
 	}
 
-	function persistLocalDoc(doc: Y.Doc) {
+	async function persistLocalDoc(doc: Y.Doc, encryptionKey: CryptoKey) {
 		try {
-			localStorage.setItem(storageKey(), updateToBase64(Y.encodeStateAsUpdate(doc)));
+			const envelope = await encryptBytes(encryptionKey, Y.encodeStateAsUpdate(doc));
+			localStorage.setItem(storageKey(), serializeEnvelope(envelope));
 		} catch {
 			// Keep editing even when local persistence is unavailable.
 		}
@@ -203,41 +211,73 @@
 		return crypto.randomUUID?.() ?? Math.random().toString(36).slice(2);
 	}
 
-	function connectLocalFallback(doc: Y.Doc) {
+	function connectLocalFallback(doc: Y.Doc, encryptionKey: CryptoKey) {
+		let pendingPersist = Promise.resolve();
+		const schedulePersist = () => {
+			pendingPersist = pendingPersist.then(() => persistLocalDoc(doc, encryptionKey));
+			void pendingPersist.catch(() => {
+				// persistLocalDoc already keeps editing available when storage fails.
+			});
+		};
+		const onStorageOnlyUpdate = () => schedulePersist();
+
 		if (typeof BroadcastChannel === 'undefined') {
-			doc.on('update', () => persistLocalDoc(doc));
-			return () => {};
+			doc.on('update', onStorageOnlyUpdate);
+			return () => doc.off('update', onStorageOnlyUpdate);
 		}
 
 		const channel = new BroadcastChannel(`syncingsh:${roomId}`);
 		const origin = fallbackOrigin();
 
+		const postEncryptedUpdate = async (update: Uint8Array) => {
+			const envelope = await encryptBytes(encryptionKey, update);
+			channel.postMessage({ origin, encryptedUpdate: envelope });
+		};
+
 		const onUpdate = (update: Uint8Array) => {
-			persistLocalDoc(doc);
-			try {
-				channel.postMessage({ origin, update: updateToBase64(update) });
-			} catch {
+			schedulePersist();
+			void postEncryptedUpdate(update).catch(() => {
 				// Local persistence still protects reload recovery if cross-tab broadcast fails.
-			}
+			});
 		};
 
 		channel.onmessage = (event) => {
-			const message = event.data as { origin?: string; update?: string; requestSync?: boolean };
+			const message = event.data as {
+				origin?: string;
+				update?: string;
+				encryptedUpdate?: unknown;
+				requestSync?: boolean;
+			};
 			if (message.origin === origin) return;
 
 			if (message.requestSync) {
-				try {
-					channel.postMessage({ origin, update: updateToBase64(Y.encodeStateAsUpdate(doc)) });
-				} catch {
+				void postEncryptedUpdate(Y.encodeStateAsUpdate(doc)).catch(() => {
 					// Ignore failed sync responses; the local document remains editable.
-				}
+				});
+				return;
+			}
+
+			if (message.encryptedUpdate) {
+				void (async () => {
+					try {
+						const envelope =
+							typeof message.encryptedUpdate === 'string'
+								? parseEncryptedEnvelope(message.encryptedUpdate)
+								: message.encryptedUpdate;
+						if (!isEncryptedEnvelope(envelope)) return;
+						Y.applyUpdate(doc, await decryptEnvelope(encryptionKey, envelope), 'remote');
+						schedulePersist();
+					} catch {
+						// Ignore updates encrypted for another room key or malformed payloads.
+					}
+				})();
 				return;
 			}
 
 			if (message.update) {
 				try {
 					Y.applyUpdate(doc, base64ToUpdate(message.update), 'remote');
-					persistLocalDoc(doc);
+					schedulePersist();
 				} catch {
 					// Ignore malformed peer updates.
 				}
@@ -273,93 +313,110 @@
 	onMount(() => {
 		if (!roomId) return;
 
-		nickname = getNickname();
-		const userColor = getUserColor();
-		const doc = new Y.Doc();
-		restoreLocalDoc(doc);
-		let cleanupLocalFallback = connectLocalFallback(doc);
+		let disposed = false;
+		let cleanupLocalFallback = () => {};
 		let cleanupProvider = () => {};
+		let activeDoc: Y.Doc | null = null;
 
-		ydoc = doc;
-		yTabs = doc.getArray<TabMeta>('tabs');
-
-		const initTabs = () => {
-			if (!yTabs) return;
-			const DEFAULT_TAB_ID = 'default';
-			const hasDefault = Array.from({ length: yTabs.length }, (_, i) => yTabs!.get(i)).some(
-				(t) => t.id === DEFAULT_TAB_ID
-			);
-			if (!hasDefault) {
-				yTabs.push([{ id: DEFAULT_TAB_ID, name: '문서 1', createdAt: Date.now() }]);
-			}
-			activeTabId = DEFAULT_TAB_ID;
-			syncTabsFromYjs();
-			yTabs.observe(() => syncTabsFromYjs());
-		};
-
-		initTabs();
-
-		const publicKey = import.meta.env.VITE_LIVEBLOCKS_PUBLIC_KEY;
-		if (!publicKey) {
-			connectionStatus = 'error';
-			errorMessage = 'Liveblocks 공개 키가 없어 이 브라우저의 로컬 복구 모드로 실행 중입니다.';
-			return () => {
-				cleanupLocalFallback();
+		void (async () => {
+			nickname = getNickname();
+			const userColor = getUserColor();
+			const encryptionKey = await importRoomKey(ensureRoomKey(new URL(window.location.href)));
+			const doc = new Y.Doc();
+			await restoreLocalDoc(doc, encryptionKey);
+			if (disposed) {
 				doc.destroy();
+				return;
+			}
+
+			cleanupLocalFallback = connectLocalFallback(doc, encryptionKey);
+			activeDoc = doc;
+
+			ydoc = doc;
+			yTabs = doc.getArray<TabMeta>('tabs');
+
+			const initTabs = () => {
+				if (!yTabs) return;
+				const DEFAULT_TAB_ID = 'default';
+				const hasDefault = Array.from({ length: yTabs.length }, (_, i) => yTabs!.get(i)).some(
+					(t) => t.id === DEFAULT_TAB_ID
+				);
+				if (!hasDefault) {
+					yTabs.push([{ id: DEFAULT_TAB_ID, name: '문서 1', createdAt: Date.now() }]);
+				}
+				activeTabId = DEFAULT_TAB_ID;
+				syncTabsFromYjs();
+				yTabs.observe(() => syncTabsFromYjs());
 			};
-		}
 
-		const client = createClient({
-			publicApiKey: publicKey
-		});
-
-		const { room, leave } = client.enterRoom(roomId);
-		const provider = getYjsProviderForRoom(room);
-		const liveblocksDoc = provider.getYDoc();
-		restoreLocalDoc(liveblocksDoc);
-		cleanupLocalFallback();
-		cleanupLocalFallback = connectLocalFallback(liveblocksDoc);
-
-		const mapStatus = (status: string) => {
-			if (status === 'connected') connectionStatus = 'connected';
-			else if (status === 'connecting' || status === 'reconnecting')
-				connectionStatus = 'connecting';
-			else if (status === 'disconnected') connectionStatus = 'disconnected';
-		};
-
-		mapStatus(room.getStatus());
-		const unsubscribeStatus = room.subscribe('status', mapStatus);
-
-		provider.awareness.setLocalStateField('user', {
-			name: nickname,
-			color: userColor
-		});
-
-		ydoc = liveblocksDoc;
-		awareness = provider.awareness;
-		connectionStatus = 'connecting';
-
-		yTabs = liveblocksDoc.getArray<TabMeta>('tabs');
-
-		if (provider.synced) {
 			initTabs();
-		} else {
-			const onSynced = () => {
-				provider.off('sync', onSynced);
-				initTabs();
-			};
-			provider.on('sync', onSynced);
-		}
 
-		cleanupProvider = () => {
-			unsubscribeStatus();
-			leave();
-		};
+			const publicKey = import.meta.env.VITE_LIVEBLOCKS_PUBLIC_KEY;
+			if (!publicKey) {
+				connectionStatus = 'error';
+				errorMessage = 'Liveblocks 공개 키가 없어 이 브라우저의 로컬 복구 모드로 실행 중입니다.';
+				return;
+			}
+
+			const client = createClient({
+				publicApiKey: publicKey
+			});
+
+			const { room, leave } = client.enterRoom(roomId);
+			const provider = getYjsProviderForRoom(room);
+			const liveblocksDoc = provider.getYDoc();
+			await restoreLocalDoc(liveblocksDoc, encryptionKey);
+			if (disposed) {
+				leave();
+				liveblocksDoc.destroy();
+				return;
+			}
+			cleanupLocalFallback();
+			cleanupLocalFallback = connectLocalFallback(liveblocksDoc, encryptionKey);
+			activeDoc = liveblocksDoc;
+
+			const mapStatus = (status: string) => {
+				if (status === 'connected') connectionStatus = 'connected';
+				else if (status === 'connecting' || status === 'reconnecting')
+					connectionStatus = 'connecting';
+				else if (status === 'disconnected') connectionStatus = 'disconnected';
+			};
+
+			mapStatus(room.getStatus());
+			const unsubscribeStatus = room.subscribe('status', mapStatus);
+
+			provider.awareness.setLocalStateField('user', {
+				name: nickname,
+				color: userColor
+			});
+
+			ydoc = liveblocksDoc;
+			awareness = provider.awareness;
+			connectionStatus = 'connecting';
+
+			yTabs = liveblocksDoc.getArray<TabMeta>('tabs');
+
+			if (provider.synced) {
+				initTabs();
+			} else {
+				const onSynced = () => {
+					provider.off('sync', onSynced);
+					initTabs();
+				};
+				provider.on('sync', onSynced);
+			}
+
+			cleanupProvider = () => {
+				unsubscribeStatus();
+				leave();
+			};
+		})();
 
 		return () => {
+			disposed = true;
 			cleanupProvider();
 			cleanupLocalFallback();
-			liveblocksDoc.destroy();
+			activeDoc?.destroy();
 		};
 	});
 </script>


### PR DESCRIPTION
## Summary
- Adds a browser Web Crypto AES-GCM envelope for room-local Yjs payloads.
- Encrypts localStorage recovery snapshots and same-browser BroadcastChannel fallback updates.
- Preserves legacy base64 local recovery reads and keeps Liveblocks Yjs sync unchanged.

## Verification
- `npm run check`
- `npm test`
- `npm run test:e2e` → 14 passed, 3 skipped without Liveblocks key
- `npx playwright test e2e/collaboration.spec.ts -g "Local reload recovery|same-browser fallback"` → 2 passed, 1 skipped
- `npx prettier --check "src/lib/utils/localEncryption.ts" "src/routes/room/[roomId]/+page.svelte" "e2e/collaboration.spec.ts"`

## Notes
- `npm run lint` still fails on pre-existing formatting warnings in `signaling/docker-compose.yml` and `signaling/README.md`; changed files pass Prettier.
- This is local recovery/fallback encryption only, not full collaborative E2EE.

Closes #42