### PR TITLE
Add encrypted snapshot recovery

### DIFF
--- a/e2e/collaboration.spec.ts
+++ b/e2e/collaboration.spec.ts
@@ -280,6 +280,30 @@ test.describe('Liveblocks sync (cross-browser, WebSocket)', () => {
 		await expect(editor2).toContainText('Encrypted transport sync works!', { timeout: 15000 });
 	});
 
+	test('late joiner should restore encrypted transport snapshot', async () => {
+		const roomPath = `/room/e2e-encrypted-snapshot-${Date.now()}?transport=encrypted`;
+
+		const page1 = await context1.newPage();
+		await page1.goto(roomPath);
+
+		const editor1 = page1.locator('.tiptap');
+		await editor1.waitFor({ timeout: 10000 });
+		await editor1.click();
+		await page1.keyboard.type('Recovered from encrypted snapshot');
+		await expect(editor1).toContainText('Recovered from encrypted snapshot');
+
+		const sharedUrl = page1.url();
+		await page1.waitForTimeout(1000);
+		await context1.close();
+
+		const page2 = await context2.newPage();
+		await page2.goto(sharedUrl);
+
+		await expect(page2.locator('.tiptap')).toContainText('Recovered from encrypted snapshot', {
+			timeout: 15000
+		});
+	});
+
 	test('presence should work across separate browsers', async () => {
 		const roomPath = '/room/e2e-liveblocks-presence';
 

--- a/src/routes/room/[roomId]/+page.svelte
+++ b/src/routes/room/[roomId]/+page.svelte
@@ -37,6 +37,8 @@
 				origin: string;
 		  };
 
+	const ENCRYPTED_SNAPSHOT_KEY = 'syncingshEncryptedSnapshot';
+
 	const roomId = $derived($page.params.roomId);
 	const isReadonly = $derived($page.url.searchParams.get('readonly') === '1');
 	const usesEncryptedTransport = $derived($page.url.searchParams.get('transport') === 'encrypted');
@@ -233,6 +235,31 @@
 		);
 	}
 
+	async function restoreEncryptedRoomSnapshot(doc: Y.Doc, encryptionKey: CryptoKey, room: any) {
+		try {
+			const { root } = await room.getStorage();
+			const stored = root.get(ENCRYPTED_SNAPSHOT_KEY);
+			if (typeof stored !== 'string') return;
+
+			const envelope = parseEncryptedEnvelope(stored);
+			if (!envelope) return;
+
+			Y.applyUpdate(doc, await decryptEnvelope(encryptionKey, envelope), 'encrypted-snapshot');
+		} catch {
+			// Snapshot recovery is best-effort; live encrypted relay may still catch up.
+		}
+	}
+
+	async function persistEncryptedRoomSnapshot(doc: Y.Doc, encryptionKey: CryptoKey, room: any) {
+		try {
+			const { root } = await room.getStorage();
+			const envelope = await encryptBytes(encryptionKey, Y.encodeStateAsUpdate(doc));
+			root.set(ENCRYPTED_SNAPSHOT_KEY, serializeEnvelope(envelope));
+		} catch {
+			// Keep editing even when durable encrypted snapshot persistence fails.
+		}
+	}
+
 	function connectLocalFallback(doc: Y.Doc, encryptionKey: CryptoKey) {
 		let pendingPersist = Promise.resolve();
 		const schedulePersist = () => {
@@ -321,6 +348,15 @@
 
 	function connectEncryptedRoomTransport(doc: Y.Doc, encryptionKey: CryptoKey, room: any) {
 		const origin = fallbackOrigin();
+		let pendingSnapshot = Promise.resolve();
+		const scheduleSnapshotPersist = () => {
+			pendingSnapshot = pendingSnapshot.then(() =>
+				persistEncryptedRoomSnapshot(doc, encryptionKey, room)
+			);
+			void pendingSnapshot.catch(() => {
+				// persistEncryptedRoomSnapshot already keeps editing available when storage fails.
+			});
+		};
 
 		const broadcastUpdate = async (update: Uint8Array) => {
 			const envelope = await encryptBytes(encryptionKey, update);
@@ -333,6 +369,7 @@
 
 		const onUpdate = (update: Uint8Array, updateOrigin: unknown) => {
 			if (updateOrigin === 'encrypted-transport') return;
+			scheduleSnapshotPersist();
 			void broadcastUpdate(update).catch(() => {
 				// The encrypted relay is best-effort; local recovery remains available.
 			});
@@ -353,6 +390,7 @@
 					const envelope = event.encryptedUpdate;
 					if (!isEncryptedEnvelope(envelope)) return;
 					Y.applyUpdate(doc, await decryptEnvelope(encryptionKey, envelope), 'encrypted-transport');
+					scheduleSnapshotPersist();
 				} catch {
 					// Ignore updates encrypted for another room key or malformed payloads.
 				}
@@ -360,6 +398,7 @@
 		});
 
 		doc.on('update', onUpdate);
+		scheduleSnapshotPersist();
 		try {
 			room.broadcastEvent({ type: 'syncingsh-sync-request', origin });
 		} catch {
@@ -441,6 +480,14 @@
 			const { room, leave } = client.enterRoom(roomId);
 
 			if (usesEncryptedTransport) {
+				await restoreEncryptedRoomSnapshot(doc, encryptionKey, room);
+				if (disposed) {
+					leave();
+					doc.destroy();
+					return;
+				}
+				syncTabsFromYjs();
+
 				const mapStatus = (status: string) => {
 					if (status === 'connected') connectionStatus = 'connected';
 					else if (status === 'connecting' || status === 'reconnecting')


### PR DESCRIPTION
## Summary
- Persists encrypted Yjs snapshots to Liveblocks storage for `?transport=encrypted` rooms.
- Restores the encrypted snapshot before wiring the encrypted event relay so late joiners can hydrate state without the plaintext Yjs provider.
- Adds a late-join E2E case for encrypted transport snapshot recovery.

## Verification
- `npm run check`
- `npm test`
- `npm run test:e2e` → 14 passed, 5 skipped without Liveblocks key
- `npx playwright test e2e/collaboration.spec.ts -g "encrypted snapshot|encrypted transport|same-browser fallback|Local reload recovery"` → 2 passed, 3 skipped without Liveblocks key
- `npx prettier --check "src/routes/room/[roomId]/+page.svelte" "e2e/collaboration.spec.ts"`

## Notes
- Liveblocks-key-gated encrypted snapshot tests are present but skipped locally without `VITE_LIVEBLOCKS_PUBLIC_KEY`.
- This is still scoped to `?transport=encrypted`; default Liveblocks Yjs provider sync remains unchanged.
- `npm run lint` still fails on pre-existing formatting warnings in `signaling/docker-compose.yml` and `signaling/README.md`; changed files pass Prettier.

Closes #46