### PR TITLE
Add encrypted write capabilities

### DIFF
--- a/e2e/collaboration.spec.ts
+++ b/e2e/collaboration.spec.ts
@@ -115,6 +115,35 @@ test.describe('Room page', () => {
 		await expect(editor).not.toContainText('Should not appear');
 	});
 
+	test('should omit writer capability from encrypted read-only links', async ({ page }) => {
+		let copiedText = '';
+		await page.addInitScript(() => {
+			Object.defineProperty(navigator, 'clipboard', {
+				value: {
+					writeText: async (value: string) => {
+						(window as any).__copiedText = value;
+					}
+				},
+				configurable: true
+			});
+		});
+
+		await page.goto(`/room/e2e-readonly-capability-${Date.now()}?transport=encrypted`);
+		await page.locator('.tiptap').waitFor({ timeout: 10000 });
+
+		await page.getByRole('button', { name: '읽기 전용 링크' }).click();
+		copiedText = await page.evaluate(() => (window as any).__copiedText ?? '');
+
+		const copiedUrl = new URL(copiedText);
+		const hashParams = new URLSearchParams(copiedUrl.hash.slice(1));
+
+		expect(copiedUrl.searchParams.get('readonly')).toBe('1');
+		expect(copiedUrl.searchParams.get('transport')).toBe('encrypted');
+		expect(hashParams.get('key')).toBeTruthy();
+		expect(hashParams.get('verifyKey')).toBeTruthy();
+		expect(hashParams.get('writeKey')).toBeNull();
+	});
+
 	test('should export current document as text', async ({ page }) => {
 		await page.goto('/room/e2e-export');
 

--- a/e2e/collaboration.spec.ts
+++ b/e2e/collaboration.spec.ts
@@ -1,5 +1,17 @@
 import { test, expect, type BrowserContext } from '@playwright/test';
 
+type BroadcastCaptureMessage = {
+	encryptedUpdate?: unknown;
+	update?: unknown;
+};
+
+declare global {
+	interface Window {
+		__copiedText?: string;
+		__syncingshBroadcastMessages?: BroadcastCaptureMessage[];
+	}
+}
+
 test.describe('Landing page', () => {
 	test('should create a new room and navigate to it', async ({ page }) => {
 		await page.goto('/');
@@ -121,7 +133,7 @@ test.describe('Room page', () => {
 			Object.defineProperty(navigator, 'clipboard', {
 				value: {
 					writeText: async (value: string) => {
-						(window as any).__copiedText = value;
+						window.__copiedText = value;
 					}
 				},
 				configurable: true
@@ -132,7 +144,7 @@ test.describe('Room page', () => {
 		await page.locator('.tiptap').waitFor({ timeout: 10000 });
 
 		await page.getByRole('button', { name: '읽기 전용 링크' }).click();
-		copiedText = await page.evaluate(() => (window as any).__copiedText ?? '');
+		copiedText = await page.evaluate(() => window.__copiedText ?? '');
 
 		const copiedUrl = new URL(copiedText);
 		const hashParams = new URLSearchParams(copiedUrl.hash.slice(1));
@@ -177,11 +189,11 @@ test.describe('Real-time collaboration (same-browser fallback)', () => {
 	test('two tabs should sync content via BroadcastChannel', async ({ context }) => {
 		await context.addInitScript(() => {
 			const OriginalBroadcastChannel = window.BroadcastChannel;
-			(window as any).__syncingshBroadcastMessages = [];
+			window.__syncingshBroadcastMessages = [];
 
 			window.BroadcastChannel = class extends OriginalBroadcastChannel {
 				postMessage(message: unknown) {
-					(window as any).__syncingshBroadcastMessages.push(message);
+					window.__syncingshBroadcastMessages?.push(message as BroadcastCaptureMessage);
 					return super.postMessage(message);
 				}
 			};
@@ -210,12 +222,10 @@ test.describe('Real-time collaboration (same-browser fallback)', () => {
 		await expect(editor2).toContainText('Synced message from tab 1', { timeout: 10000 });
 
 		const broadcastMessages = await page1.evaluate(() =>
-			((window as any).__syncingshBroadcastMessages ?? []).filter(
-				(message: any) => message.encryptedUpdate
-			)
+			(window.__syncingshBroadcastMessages ?? []).filter((message) => message.encryptedUpdate)
 		);
 		expect(broadcastMessages.length).toBeGreaterThan(0);
-		expect(broadcastMessages.every((message: any) => !message.update)).toBe(true);
+		expect(broadcastMessages.every((message) => !message.update)).toBe(true);
 		expect(JSON.stringify(broadcastMessages)).not.toContain('Synced message from tab 1');
 	});
 

--- a/signaling/README.md
+++ b/signaling/README.md
@@ -31,16 +31,16 @@ npm start       # node dist/index.js
 
 ## 환경변수
 
-| 변수 | 기본값 | 설명 |
-|---|---|---|
+| 변수   | 기본값 | 설명      |
+| ------ | ------ | --------- |
 | `PORT` | `4444` | 서버 포트 |
 
 ## 엔드포인트
 
-| 경로 | 프로토콜 | 설명 |
-|---|---|---|
-| `/` | WebSocket | y-webrtc 시그널링 (subscribe, publish, ping) |
-| `/health` | HTTP GET | 헬스체크 (`ok` 반환) |
+| 경로      | 프로토콜  | 설명                                         |
+| --------- | --------- | -------------------------------------------- |
+| `/`       | WebSocket | y-webrtc 시그널링 (subscribe, publish, ping) |
+| `/health` | HTTP GET  | 헬스체크 (`ok` 반환)                         |
 
 ## 프로토콜
 
@@ -85,7 +85,7 @@ services:
     build: .
     restart: unless-stopped
     ports:
-      - "4444:4444"       # 호스트:컨테이너
+      - '4444:4444' # 호스트:컨테이너
     environment:
       - PORT=4444
 ```

--- a/signaling/docker-compose.yml
+++ b/signaling/docker-compose.yml
@@ -3,11 +3,11 @@ services:
     build: .
     restart: unless-stopped
     ports:
-      - "4444:4444"
+      - '4444:4444'
     environment:
       - PORT=4444
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:4444/health"]
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:4444/health']
       interval: 30s
       timeout: 5s
       retries: 3

--- a/src/lib/utils/localEncryption.svelte.spec.ts
+++ b/src/lib/utils/localEncryption.svelte.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest';
+import {
+	ensureRoomKey,
+	ensureWriteCapability,
+	removeWriteCapability,
+	signText,
+	verifyTextSignature
+} from './localEncryption';
+
+describe('encrypted room capabilities', () => {
+	function sameOriginRoomUrl(path: string) {
+		const url = new URL(window.location.href);
+		url.pathname = path;
+		url.search = '?transport=encrypted';
+		url.hash = '';
+		return url;
+	}
+
+	test('read-only links keep read capability and remove write capability', async () => {
+		const url = sameOriginRoomUrl('/room/capability-test');
+		const roomKey = ensureRoomKey(url);
+		await ensureWriteCapability(url);
+
+		const writerHash = new URLSearchParams(url.hash.slice(1));
+		expect(writerHash.get('key')).toBe(roomKey);
+		expect(writerHash.get('verifyKey')).toBeTruthy();
+		expect(writerHash.get('writeKey')).toBeTruthy();
+
+		const readonlyUrl = removeWriteCapability(url);
+		const readonlyHash = new URLSearchParams(readonlyUrl.hash.slice(1));
+
+		expect(readonlyHash.get('key')).toBe(roomKey);
+		expect(readonlyHash.get('verifyKey')).toBe(writerHash.get('verifyKey'));
+		expect(readonlyHash.get('writeKey')).toBeNull();
+	});
+
+	test('read-only capability can verify but cannot sign writes', async () => {
+		const writerUrl = sameOriginRoomUrl('/room/signature-test');
+		ensureRoomKey(writerUrl);
+		const writerCapability = await ensureWriteCapability(writerUrl);
+		const readonlyCapability = await ensureWriteCapability(removeWriteCapability(writerUrl));
+		const signature = await signText(writerCapability.privateKey!, 'encrypted-payload');
+
+		expect(writerCapability.privateKey).toBeTruthy();
+		expect(readonlyCapability.privateKey).toBeNull();
+		expect(readonlyCapability.publicKey).toBeTruthy();
+		expect(
+			await verifyTextSignature(readonlyCapability.publicKey!, 'encrypted-payload', signature)
+		).toBe(true);
+		expect(await verifyTextSignature(readonlyCapability.publicKey!, 'tampered', signature)).toBe(
+			false
+		);
+	});
+
+	test('read-only mode does not mint writer capability without a verify key', async () => {
+		const readonlyUrl = sameOriginRoomUrl('/room/manual-readonly');
+		ensureRoomKey(readonlyUrl);
+		readonlyUrl.searchParams.set('readonly', '1');
+
+		const capability = await ensureWriteCapability(readonlyUrl, false);
+		const hash = new URLSearchParams(readonlyUrl.hash.slice(1));
+
+		expect(capability.privateKey).toBeNull();
+		expect(capability.publicKey).toBeNull();
+		expect(hash.get('writeKey')).toBeNull();
+		expect(hash.get('verifyKey')).toBeNull();
+	});
+});

--- a/src/lib/utils/localEncryption.ts
+++ b/src/lib/utils/localEncryption.ts
@@ -1,6 +1,13 @@
 const KEY_HASH_PARAM = 'key';
+const WRITE_KEY_HASH_PARAM = 'writeKey';
+const VERIFY_KEY_HASH_PARAM = 'verifyKey';
 const KEY_BYTE_LENGTH = 32;
 const IV_BYTE_LENGTH = 12;
+
+export interface WriteCapability {
+	privateKey: CryptoKey | null;
+	publicKey: CryptoKey | null;
+}
 
 export interface EncryptedEnvelope {
 	v: 1;
@@ -24,6 +31,19 @@ function base64UrlToBytes(value: string): Uint8Array {
 
 function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
 	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function textToBytes(value: string): Uint8Array {
+	return new TextEncoder().encode(value);
+}
+
+function encodeJson(value: unknown): string {
+	return bytesToBase64Url(textToBytes(JSON.stringify(value)));
+}
+
+function decodeJson<T>(value: string): T {
+	const bytes = base64UrlToBytes(value);
+	return JSON.parse(new TextDecoder().decode(bytes)) as T;
 }
 
 export function isEncryptedEnvelope(value: unknown): value is EncryptedEnvelope {
@@ -56,6 +76,60 @@ export function ensureRoomKey(url: URL): string {
 	url.hash = hashParams.toString();
 	history.replaceState(history.state, '', url);
 	return generatedKey;
+}
+
+export function removeWriteCapability(url: URL): URL {
+	const nextUrl = new URL(url.toString());
+	const hashParams = new URLSearchParams(nextUrl.hash.slice(1));
+	hashParams.delete(WRITE_KEY_HASH_PARAM);
+	nextUrl.hash = hashParams.toString();
+	return nextUrl;
+}
+
+export async function ensureWriteCapability(
+	url: URL,
+	allowGenerate = true
+): Promise<WriteCapability> {
+	const hashParams = new URLSearchParams(url.hash.slice(1));
+	const existingPrivateKey = hashParams.get(WRITE_KEY_HASH_PARAM);
+	const existingPublicKey = hashParams.get(VERIFY_KEY_HASH_PARAM);
+
+	if (existingPrivateKey && existingPublicKey) {
+		return {
+			privateKey: await importSigningPrivateKey(existingPrivateKey),
+			publicKey: await importSigningPublicKey(existingPublicKey)
+		};
+	}
+
+	if (existingPublicKey) {
+		return {
+			privateKey: null,
+			publicKey: await importSigningPublicKey(existingPublicKey)
+		};
+	}
+
+	if (!allowGenerate) {
+		return {
+			privateKey: null,
+			publicKey: null
+		};
+	}
+
+	const keyPair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+		'sign',
+		'verify'
+	]);
+	const privateJwk = await crypto.subtle.exportKey('jwk', keyPair.privateKey);
+	const publicJwk = await crypto.subtle.exportKey('jwk', keyPair.publicKey);
+	hashParams.set(WRITE_KEY_HASH_PARAM, encodeJson(privateJwk));
+	hashParams.set(VERIFY_KEY_HASH_PARAM, encodeJson(publicJwk));
+	url.hash = hashParams.toString();
+	history.replaceState(history.state, '', url);
+
+	return {
+		privateKey: keyPair.privateKey,
+		publicKey: keyPair.publicKey
+	};
 }
 
 export function parseEncryptedEnvelope(value: string): EncryptedEnvelope | null {
@@ -108,6 +182,52 @@ export async function decryptEnvelope(
 	);
 
 	return new Uint8Array(plaintext);
+}
+
+export async function signText(privateKey: CryptoKey, value: string): Promise<string> {
+	const signature = await crypto.subtle.sign(
+		{ name: 'ECDSA', hash: 'SHA-256' },
+		privateKey,
+		toArrayBuffer(textToBytes(value))
+	);
+	return bytesToBase64Url(new Uint8Array(signature));
+}
+
+export async function verifyTextSignature(
+	publicKey: CryptoKey,
+	value: string,
+	signature: string
+): Promise<boolean> {
+	try {
+		return await crypto.subtle.verify(
+			{ name: 'ECDSA', hash: 'SHA-256' },
+			publicKey,
+			toArrayBuffer(base64UrlToBytes(signature)),
+			toArrayBuffer(textToBytes(value))
+		);
+	} catch {
+		return false;
+	}
+}
+
+async function importSigningPrivateKey(value: string): Promise<CryptoKey> {
+	return crypto.subtle.importKey(
+		'jwk',
+		decodeJson<JsonWebKey>(value),
+		{ name: 'ECDSA', namedCurve: 'P-256' },
+		false,
+		['sign']
+	);
+}
+
+async function importSigningPublicKey(value: string): Promise<CryptoKey> {
+	return crypto.subtle.importKey(
+		'jwk',
+		decodeJson<JsonWebKey>(value),
+		{ name: 'ECDSA', namedCurve: 'P-256' },
+		false,
+		['verify']
+	);
 }
 
 export function serializeEnvelope(envelope: EncryptedEnvelope): string {

--- a/src/routes/room/[roomId]/+page.svelte
+++ b/src/routes/room/[roomId]/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/stores';
 	import * as Y from 'yjs';
 	import { createClient } from '@liveblocks/client';
+	import type { JsonObject } from '@liveblocks/client';
 	import { getYjsProviderForRoom } from '@liveblocks/yjs';
 	import Editor from '$lib/components/Editor.svelte';
 	import TabBar from '$lib/components/TabBar.svelte';
@@ -22,7 +23,7 @@
 		serializeEnvelope,
 		verifyTextSignature
 	} from '$lib/utils/localEncryption';
-	import type { WriteCapability } from '$lib/utils/localEncryption';
+	import type { EncryptedEnvelope, WriteCapability } from '$lib/utils/localEncryption';
 	import type { ConnectionStatus } from '$lib/types/yjs';
 
 	interface TabMeta {
@@ -32,21 +33,41 @@
 	}
 
 	type EncryptedTransportEvent =
-		| {
+		| (JsonObject & {
 				type: 'syncingsh-yjs-update';
 				origin: string;
-				signedUpdate: unknown;
-		  }
-		| {
+				signedUpdate: SignedEncryptedPayload;
+		  })
+		| (JsonObject & {
 				type: 'syncingsh-sync-request';
 				origin: string;
-		  };
+		  });
 
 	const ENCRYPTED_SNAPSHOT_KEY = 'syncingshEncryptedSnapshot';
 
-	interface SignedEncryptedPayload {
-		envelope: unknown;
+	type SignedEncryptedPayload = JsonObject & {
+		envelope: JsonObject;
 		signature: string;
+	};
+
+	interface EncryptedStorageRoot {
+		get(key: string): unknown;
+		set(key: string, value: string): void;
+	}
+
+	interface EncryptedRoom {
+		broadcastEvent(event: EncryptedTransportEvent): void;
+		getStorage(): Promise<{ root: EncryptedStorageRoot }>;
+		subscribe(type: 'event', callback: (message: { event: unknown }) => void): () => void;
+	}
+
+	interface AwarenessLike {
+		setLocalStateField(field: string, value: unknown): void;
+		getStates(): Map<number, unknown>;
+		on(event: string, cb: () => void): void;
+		off(event: string, cb: () => void): void;
+		clientID?: number;
+		doc?: { clientID: number };
 	}
 
 	const roomId = $derived($page.params.roomId);
@@ -54,7 +75,7 @@
 	const usesEncryptedTransport = $derived($page.url.searchParams.get('transport') === 'encrypted');
 
 	let ydoc = $state<Y.Doc | null>(null);
-	let awareness = $state<any | null>(null);
+	let awareness = $state<AwarenessLike | null>(null);
 	let connectionStatus = $state<ConnectionStatus>('disconnected');
 	let nickname = $state('');
 	let editingName = $state(false);
@@ -87,12 +108,12 @@
 
 	function syncTabsFromYjs() {
 		if (!yTabs) return;
-		const seen = new Set<string>();
+		const seen: string[] = [];
 		const arr: TabMeta[] = [];
 		for (let i = 0; i < yTabs.length; i++) {
 			const t = yTabs.get(i);
-			if (!seen.has(t.id)) {
-				seen.add(t.id);
+			if (!seen.includes(t.id)) {
+				seen.push(t.id);
 				arr.push(t);
 			}
 		}
@@ -254,11 +275,11 @@
 		);
 	}
 
-	async function signEnvelope(envelope: unknown, capability: WriteCapability) {
+	async function signEnvelope(envelope: EncryptedEnvelope, capability: WriteCapability) {
 		if (!capability.privateKey) return null;
 		const serialized = JSON.stringify(envelope);
 		return {
-			envelope,
+			envelope: envelope as unknown as JsonObject,
 			signature: await signText(capability.privateKey, serialized)
 		};
 	}
@@ -277,7 +298,7 @@
 		doc: Y.Doc,
 		encryptionKey: CryptoKey,
 		writeCapability: WriteCapability,
-		room: any
+		room: EncryptedRoom
 	) {
 		try {
 			const { root } = await room.getStorage();
@@ -298,7 +319,7 @@
 		doc: Y.Doc,
 		encryptionKey: CryptoKey,
 		writeCapability: WriteCapability,
-		room: any
+		room: EncryptedRoom
 	) {
 		try {
 			if (!writeCapability.privateKey) return;
@@ -407,7 +428,7 @@
 		doc: Y.Doc,
 		encryptionKey: CryptoKey,
 		writeCapability: WriteCapability,
-		room: any
+		room: EncryptedRoom
 	) {
 		const origin = fallbackOrigin();
 		let pendingSnapshot = Promise.resolve();

--- a/src/routes/room/[roomId]/+page.svelte
+++ b/src/routes/room/[roomId]/+page.svelte
@@ -13,11 +13,16 @@
 		decryptEnvelope,
 		encryptBytes,
 		ensureRoomKey,
+		ensureWriteCapability,
 		importRoomKey,
 		isEncryptedEnvelope,
 		parseEncryptedEnvelope,
-		serializeEnvelope
+		removeWriteCapability,
+		signText,
+		serializeEnvelope,
+		verifyTextSignature
 	} from '$lib/utils/localEncryption';
+	import type { WriteCapability } from '$lib/utils/localEncryption';
 	import type { ConnectionStatus } from '$lib/types/yjs';
 
 	interface TabMeta {
@@ -30,7 +35,7 @@
 		| {
 				type: 'syncingsh-yjs-update';
 				origin: string;
-				encryptedUpdate: unknown;
+				signedUpdate: unknown;
 		  }
 		| {
 				type: 'syncingsh-sync-request';
@@ -38,6 +43,11 @@
 		  };
 
 	const ENCRYPTED_SNAPSHOT_KEY = 'syncingshEncryptedSnapshot';
+
+	interface SignedEncryptedPayload {
+		envelope: unknown;
+		signature: string;
+	}
 
 	const roomId = $derived($page.params.roomId);
 	const isReadonly = $derived($page.url.searchParams.get('readonly') === '1');
@@ -160,7 +170,7 @@
 	}
 
 	async function copyReadonlyLink() {
-		const url = new URL(window.location.href);
+		const url = removeWriteCapability(new URL(window.location.href));
 		url.searchParams.set('readonly', '1');
 
 		try {
@@ -235,13 +245,47 @@
 		);
 	}
 
-	async function restoreEncryptedRoomSnapshot(doc: Y.Doc, encryptionKey: CryptoKey, room: any) {
+	function isSignedEncryptedPayload(value: unknown): value is SignedEncryptedPayload {
+		return (
+			!!value &&
+			typeof value === 'object' &&
+			'envelope' in value &&
+			typeof (value as SignedEncryptedPayload).signature === 'string'
+		);
+	}
+
+	async function signEnvelope(envelope: unknown, capability: WriteCapability) {
+		if (!capability.privateKey) return null;
+		const serialized = JSON.stringify(envelope);
+		return {
+			envelope,
+			signature: await signText(capability.privateKey, serialized)
+		};
+	}
+
+	async function verifySignedEnvelope(payload: unknown, capability: WriteCapability) {
+		if (!capability.publicKey || !isSignedEncryptedPayload(payload)) return null;
+		const verified = await verifyTextSignature(
+			capability.publicKey,
+			JSON.stringify(payload.envelope),
+			payload.signature
+		);
+		return verified && isEncryptedEnvelope(payload.envelope) ? payload.envelope : null;
+	}
+
+	async function restoreEncryptedRoomSnapshot(
+		doc: Y.Doc,
+		encryptionKey: CryptoKey,
+		writeCapability: WriteCapability,
+		room: any
+	) {
 		try {
 			const { root } = await room.getStorage();
 			const stored = root.get(ENCRYPTED_SNAPSHOT_KEY);
 			if (typeof stored !== 'string') return;
 
-			const envelope = parseEncryptedEnvelope(stored);
+			const payload = JSON.parse(stored) as unknown;
+			const envelope = await verifySignedEnvelope(payload, writeCapability);
 			if (!envelope) return;
 
 			Y.applyUpdate(doc, await decryptEnvelope(encryptionKey, envelope), 'encrypted-snapshot');
@@ -250,17 +294,25 @@
 		}
 	}
 
-	async function persistEncryptedRoomSnapshot(doc: Y.Doc, encryptionKey: CryptoKey, room: any) {
+	async function persistEncryptedRoomSnapshot(
+		doc: Y.Doc,
+		encryptionKey: CryptoKey,
+		writeCapability: WriteCapability,
+		room: any
+	) {
 		try {
+			if (!writeCapability.privateKey) return;
 			const { root } = await room.getStorage();
 			const envelope = await encryptBytes(encryptionKey, Y.encodeStateAsUpdate(doc));
-			root.set(ENCRYPTED_SNAPSHOT_KEY, serializeEnvelope(envelope));
+			const signedPayload = await signEnvelope(envelope, writeCapability);
+			if (!signedPayload) return;
+			root.set(ENCRYPTED_SNAPSHOT_KEY, JSON.stringify(signedPayload));
 		} catch {
 			// Keep editing even when durable encrypted snapshot persistence fails.
 		}
 	}
 
-	function connectLocalFallback(doc: Y.Doc, encryptionKey: CryptoKey) {
+	function connectLocalFallback(doc: Y.Doc, encryptionKey: CryptoKey, canWrite = true) {
 		let pendingPersist = Promise.resolve();
 		const schedulePersist = () => {
 			pendingPersist = pendingPersist.then(() => persistLocalDoc(doc, encryptionKey));
@@ -268,7 +320,11 @@
 				// persistLocalDoc already keeps editing available when storage fails.
 			});
 		};
-		const onStorageOnlyUpdate = () => schedulePersist();
+		const canRebroadcastUpdate = (updateOrigin: unknown) =>
+			canWrite || updateOrigin === 'remote' || updateOrigin === 'encrypted-transport';
+		const onStorageOnlyUpdate = (_update: Uint8Array, updateOrigin: unknown) => {
+			if (canRebroadcastUpdate(updateOrigin)) schedulePersist();
+		};
 
 		if (typeof BroadcastChannel === 'undefined') {
 			doc.on('update', onStorageOnlyUpdate);
@@ -283,7 +339,8 @@
 			channel.postMessage({ origin, encryptedUpdate: envelope });
 		};
 
-		const onUpdate = (update: Uint8Array) => {
+		const onUpdate = (update: Uint8Array, updateOrigin: unknown) => {
+			if (!canRebroadcastUpdate(updateOrigin)) return;
 			schedulePersist();
 			void postEncryptedUpdate(update).catch(() => {
 				// Local persistence still protects reload recovery if cross-tab broadcast fails.
@@ -346,12 +403,17 @@
 		};
 	}
 
-	function connectEncryptedRoomTransport(doc: Y.Doc, encryptionKey: CryptoKey, room: any) {
+	function connectEncryptedRoomTransport(
+		doc: Y.Doc,
+		encryptionKey: CryptoKey,
+		writeCapability: WriteCapability,
+		room: any
+	) {
 		const origin = fallbackOrigin();
 		let pendingSnapshot = Promise.resolve();
 		const scheduleSnapshotPersist = () => {
 			pendingSnapshot = pendingSnapshot.then(() =>
-				persistEncryptedRoomSnapshot(doc, encryptionKey, room)
+				persistEncryptedRoomSnapshot(doc, encryptionKey, writeCapability, room)
 			);
 			void pendingSnapshot.catch(() => {
 				// persistEncryptedRoomSnapshot already keeps editing available when storage fails.
@@ -359,11 +421,14 @@
 		};
 
 		const broadcastUpdate = async (update: Uint8Array) => {
+			if (!writeCapability.privateKey) return;
 			const envelope = await encryptBytes(encryptionKey, update);
+			const signedUpdate = await signEnvelope(envelope, writeCapability);
+			if (!signedUpdate) return;
 			room.broadcastEvent({
 				type: 'syncingsh-yjs-update',
 				origin,
-				encryptedUpdate: envelope
+				signedUpdate
 			});
 		};
 
@@ -387,8 +452,8 @@
 
 			void (async () => {
 				try {
-					const envelope = event.encryptedUpdate;
-					if (!isEncryptedEnvelope(envelope)) return;
+					const envelope = await verifySignedEnvelope(event.signedUpdate, writeCapability);
+					if (!envelope) return;
 					Y.applyUpdate(doc, await decryptEnvelope(encryptionKey, envelope), 'encrypted-transport');
 					scheduleSnapshotPersist();
 				} catch {
@@ -436,7 +501,11 @@
 		void (async () => {
 			nickname = getNickname();
 			const userColor = getUserColor();
-			const encryptionKey = await importRoomKey(ensureRoomKey(new URL(window.location.href)));
+			const roomUrl = new URL(window.location.href);
+			const encryptionKey = await importRoomKey(ensureRoomKey(roomUrl));
+			const writeCapability = usesEncryptedTransport
+				? await ensureWriteCapability(roomUrl, !isReadonly)
+				: null;
 			const doc = new Y.Doc();
 			await restoreLocalDoc(doc, encryptionKey);
 			if (disposed) {
@@ -444,7 +513,7 @@
 				return;
 			}
 
-			cleanupLocalFallback = connectLocalFallback(doc, encryptionKey);
+			cleanupLocalFallback = connectLocalFallback(doc, encryptionKey, !isReadonly);
 			activeDoc = doc;
 
 			ydoc = doc;
@@ -480,7 +549,8 @@
 			const { room, leave } = client.enterRoom(roomId);
 
 			if (usesEncryptedTransport) {
-				await restoreEncryptedRoomSnapshot(doc, encryptionKey, room);
+				if (!writeCapability) return;
+				await restoreEncryptedRoomSnapshot(doc, encryptionKey, writeCapability, room);
 				if (disposed) {
 					leave();
 					doc.destroy();
@@ -497,7 +567,12 @@
 
 				mapStatus(room.getStatus());
 				const unsubscribeStatus = room.subscribe('status', mapStatus);
-				cleanupEncryptedTransport = connectEncryptedRoomTransport(doc, encryptionKey, room);
+				cleanupEncryptedTransport = connectEncryptedRoomTransport(
+					doc,
+					encryptionKey,
+					writeCapability,
+					room
+				);
 				cleanupProvider = () => {
 					unsubscribeStatus();
 					leave();
@@ -514,7 +589,7 @@
 				return;
 			}
 			cleanupLocalFallback();
-			cleanupLocalFallback = connectLocalFallback(liveblocksDoc, encryptionKey);
+			cleanupLocalFallback = connectLocalFallback(liveblocksDoc, encryptionKey, !isReadonly);
 			activeDoc = liveblocksDoc;
 
 			const mapStatus = (status: string) => {


### PR DESCRIPTION
## Summary
- Add URL-hash write/verify capabilities for encrypted transport rooms.
- Sign encrypted Liveblocks relay updates and encrypted room snapshots before accepting them.
- Strip writer capability from encrypted read-only links and cover the behavior with unit/E2E tests.

## Verification
- npm run check
- npm test
- npm run test:e2e
- npx prettier --check changed files
- npm run lint was attempted, but repo-wide Prettier warnings remain in pre-existing signaling/docker-compose.yml and signaling/README.md.

Closes #48