### PR TITLE
Stabilize encrypted snapshot recovery

### DIFF
--- a/e2e/collaboration.spec.ts
+++ b/e2e/collaboration.spec.ts
@@ -9,6 +9,8 @@ declare global {
 	interface Window {
 		__copiedText?: string;
 		__syncingshBroadcastMessages?: BroadcastCaptureMessage[];
+		__syncingshEncryptedSnapshotPersistedAt?: number;
+		__syncingshEncryptedSnapshotPersistedCount?: number;
 	}
 }
 
@@ -323,16 +325,36 @@ test.describe('Liveblocks sync (cross-browser, WebSocket)', () => {
 		const roomPath = `/room/e2e-encrypted-snapshot-${Date.now()}?transport=encrypted`;
 
 		const page1 = await context1.newPage();
+		await page1.addInitScript(() => {
+			window.__syncingshEncryptedSnapshotPersistedAt = 0;
+			window.__syncingshEncryptedSnapshotPersistedCount = 0;
+			window.addEventListener('syncingsh:encrypted-snapshot-persisted', () => {
+				window.__syncingshEncryptedSnapshotPersistedAt = Date.now();
+				window.__syncingshEncryptedSnapshotPersistedCount =
+					(window.__syncingshEncryptedSnapshotPersistedCount ?? 0) + 1;
+			});
+		});
 		await page1.goto(roomPath);
 
 		const editor1 = page1.locator('.tiptap');
 		await editor1.waitFor({ timeout: 10000 });
+		const previousSnapshotCount = await page1.evaluate(
+			() => window.__syncingshEncryptedSnapshotPersistedCount ?? 0
+		);
 		await editor1.click();
 		await page1.keyboard.type('Recovered from encrypted snapshot');
 		await expect(editor1).toContainText('Recovered from encrypted snapshot');
 
 		const sharedUrl = page1.url();
-		await page1.waitForTimeout(1000);
+		await page1.waitForFunction(
+			(snapshotCount) => {
+				const count = window.__syncingshEncryptedSnapshotPersistedCount ?? 0;
+				const persistedAt = window.__syncingshEncryptedSnapshotPersistedAt ?? 0;
+				return count > snapshotCount && Date.now() - persistedAt > 500;
+			},
+			previousSnapshotCount,
+			{ timeout: 15000 }
+		);
 		await context1.close();
 
 		const page2 = await context2.newPage();

--- a/src/routes/room/[roomId]/+page.svelte
+++ b/src/routes/room/[roomId]/+page.svelte
@@ -328,6 +328,7 @@
 			const signedPayload = await signEnvelope(envelope, writeCapability);
 			if (!signedPayload) return;
 			root.set(ENCRYPTED_SNAPSHOT_KEY, JSON.stringify(signedPayload));
+			window.dispatchEvent(new CustomEvent('syncingsh:encrypted-snapshot-persisted'));
 		} catch {
 			// Keep editing even when durable encrypted snapshot persistence fails.
 		}
@@ -431,13 +432,21 @@
 		room: EncryptedRoom
 	) {
 		const origin = fallbackOrigin();
-		let pendingSnapshot = Promise.resolve();
+		let pendingSnapshot: Promise<void> | null = null;
+		let snapshotRequested = false;
 		const scheduleSnapshotPersist = () => {
-			pendingSnapshot = pendingSnapshot.then(() =>
-				persistEncryptedRoomSnapshot(doc, encryptionKey, writeCapability, room)
-			);
-			void pendingSnapshot.catch(() => {
-				// persistEncryptedRoomSnapshot already keeps editing available when storage fails.
+			if (pendingSnapshot) {
+				snapshotRequested = true;
+				return;
+			}
+
+			pendingSnapshot = (async () => {
+				do {
+					snapshotRequested = false;
+					await persistEncryptedRoomSnapshot(doc, encryptionKey, writeCapability, room);
+				} while (snapshotRequested);
+			})().finally(() => {
+				pendingSnapshot = null;
 			});
 		};
 
@@ -742,21 +751,21 @@
 		</div>
 	{/if}
 
-	{#if ydoc && tabs.length > 0}
-		<TabBar
-			{tabs}
-			{activeTabId}
-			onswitch={switchTab}
-			onadd={addTab}
-			onclose={closeTab}
-			onrename={renameTab}
-		/>
-
-		{#if activeFragment}
-			{#key activeTabId}
-				<Editor fragment={activeFragment} editable={!isReadonly} />
-			{/key}
+	{#if ydoc && activeFragment}
+		{#if tabs.length > 0}
+			<TabBar
+				{tabs}
+				{activeTabId}
+				onswitch={switchTab}
+				onadd={addTab}
+				onclose={closeTab}
+				onrename={renameTab}
+			/>
 		{/if}
+
+		{#key activeTabId}
+			<Editor fragment={activeFragment} editable={!isReadonly} />
+		{/key}
 	{:else if connectionStatus === 'connecting'}
 		<div class="flex h-64 items-center justify-center text-gray-400">서버에 연결 중입니다...</div>
 	{:else if connectionStatus === 'disconnected'}


### PR DESCRIPTION
## Summary
- Coalesce encrypted snapshot persistence so the latest document state wins instead of queuing every keystroke.
- Persist the current encrypted document once the encrypted transport attaches, covering edits made before Liveblocks connection finishes.
- Make the keyed E2E wait for an encrypted snapshot persistence signal instead of a fixed timeout.

## Verification
- npm run check
- npm test
- VITE_LIVEBLOCKS_PUBLIC_KEY=pk_... npm run test:e2e
- npm run lint